### PR TITLE
add nano -t switch if editor.save_required is False

### DIFF
--- a/click/_termui_impl.py
+++ b/click/_termui_impl.py
@@ -395,13 +395,18 @@ class Editor(object):
     def edit_file(self, filename):
         import subprocess
         editor = self.get_editor()
+        # Allow nano to skip the save prompt if save is not required
+        if editor == 'nano' and not self.require_save:
+            no_save = '-t'
+        else:
+            no_save = ''
         if self.env:
             environ = os.environ.copy()
             environ.update(self.env)
         else:
             environ = None
         try:
-            c = subprocess.Popen('%s "%s"' % (editor, filename),
+            c = subprocess.Popen('%s %s "%s"' % (editor, no_save, filename),
                                  env=environ, shell=True)
             exit_code = c.wait()
             if exit_code != 0:


### PR DESCRIPTION
allows users to exit nano without it asking to save changes if calling edit(save_required=False)